### PR TITLE
Declare the explicit requirement for (fake)root

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,6 +7,7 @@ Standards-Version: 3.9.5
 Homepage: http://shh.thathost.com/pub-unix/#snake4
 Vcs-Git: git://github.com/alexdantas/snake4.debian.git -b master
 Vcs-Browser: https://github.com/alexdantas/snake4.debian
+Rules-Requires-Root: binary-targets
 
 Package: snake4
 Architecture: any


### PR DESCRIPTION
The snake4 package currently requires (fake)root to produce the debs due to static non-root:root ownerships in the debs.